### PR TITLE
update links to blog (ghost/wordpress explanation)

### DIFF
--- a/frontend/pages/partials/header.template.html
+++ b/frontend/pages/partials/header.template.html
@@ -22,12 +22,12 @@
 					</a>
 				</li>
 				<li>
-					<a href="https://maximilianehlers.com/using-freelytics-on-ghost/">
+					<a href="https://maximilianehlers.com/blog/using-freelytics-on-ghost/">
 					 Using freelytics with Ghost 
 					</a>
 				</li>
 				<li>
-					<a href="https://maximilianehlers.com/using-freelytics-on-wordpress/">
+					<a href="https://maximilianehlers.com/blog/using-freelytics-on-wordpress/">
 					 Using freelytics with Wordpress
 					</a>
 				</li>


### PR DESCRIPTION
Just noticed you had updated your blog structure, so these links stopped working

