### PR TITLE
update copy button

### DIFF
--- a/frontend/pages/generate-tracking-script.vue
+++ b/frontend/pages/generate-tracking-script.vue
@@ -10,7 +10,7 @@
         <a-button
           class="copy-to-clipboard-button"
           data-clipboard-target="#script-area"
-        >Cut to clipboard</a-button>
+        >Copy to clipboard</a-button>
       </a-col>
     </a-row>
     <a-card title="Script">


### PR DESCRIPTION
Renamed the copy button from `cut to clipboard` to `copy to clipboard`

closes #22 